### PR TITLE
improve: execute startosinstall in safe

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -376,9 +376,9 @@ if [[ ${pwrStatus} == "OK" ]] && [[ ${spaceStatus} == "OK" ]]; then
     fi
 
     if [ "$versionMajor" -ge 14 ]; then
-        "$OSInstaller/Contents/Resources/startosinstall" $eraseopt --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" &
+        eval /usr/bin/nohup "\"$OSInstaller/Contents/Resources/startosinstall\"" "$eraseopt" --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" &
     else
-        "$OSInstaller/Contents/Resources/startosinstall" $eraseopt --applicationpath "$OSInstaller" --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" &
+        eval /usr/bin/nohup "\"$OSInstaller/Contents/Resources/startosinstall\"" "$eraseopt" --applicationpath "\"$OSInstaller\"" --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" &
     fi
     /bin/sleep 3
 else

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -375,10 +375,11 @@ if [[ ${pwrStatus} == "OK" ]] && [[ ${spaceStatus} == "OK" ]]; then
         /bin/echo "   Script is configured for Erase and Install of macOS."
     fi
 
+    osinstallLogfile="/var/log/startosinstall.log"
     if [ "$versionMajor" -ge 14 ]; then
-        eval /usr/bin/nohup "\"$OSInstaller/Contents/Resources/startosinstall\"" "$eraseopt" --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" &
+        eval /usr/bin/nohup "\"$OSInstaller/Contents/Resources/startosinstall\"" "$eraseopt" --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" >> "$osinstallLogfile" &
     else
-        eval /usr/bin/nohup "\"$OSInstaller/Contents/Resources/startosinstall\"" "$eraseopt" --applicationpath "\"$OSInstaller\"" --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" &
+        eval /usr/bin/nohup "\"$OSInstaller/Contents/Resources/startosinstall\"" "$eraseopt" --applicationpath "\"$OSInstaller\"" --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" >> "$osinstallLogfile" &
     fi
     /bin/sleep 3
 else

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -261,7 +261,7 @@ fi
 # CREATE FIRST BOOT SCRIPT
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-/bin/mkdir /usr/local/jamfps
+/bin/mkdir -p /usr/local/jamfps
 
 /bin/echo "#!/bin/bash
 ## First Run Script to remove the installer.

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -225,11 +225,6 @@ loopCount=0
 while [[ $loopCount -lt 3 ]]; do
     if [ -e "$OSInstaller" ]; then
         /bin/echo "$OSInstaller found, checking version."
-        if [ ! -f "$OSInstaller/Contents/SharedSupport/InstallInfo.plist" ]; then
-            echo "Failed to get OS version info."
-            echo "Not found: $OSInstaller/Contents/SharedSupport/InstallInfo.plist"
-            cleanExit 0
-        fi
         OSVersion=$(/usr/libexec/PlistBuddy -c 'Print :"System Image Info":version' "$OSInstaller/Contents/SharedSupport/InstallInfo.plist")
         /bin/echo "OSVersion is $OSVersion"
         if [ "$OSVersion" = "$version" ]; then

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -225,6 +225,11 @@ loopCount=0
 while [[ $loopCount -lt 3 ]]; do
     if [ -e "$OSInstaller" ]; then
         /bin/echo "$OSInstaller found, checking version."
+        if [ ! -f "$OSInstaller/Contents/SharedSupport/InstallInfo.plist" ]; then
+            echo "Failed to get OS version info."
+            echo "Not found: $OSInstaller/Contents/SharedSupport/InstallInfo.plist"
+            cleanExit 0
+        fi
         OSVersion=$(/usr/libexec/PlistBuddy -c 'Print :"System Image Info":version' "$OSInstaller/Contents/SharedSupport/InstallInfo.plist")
         /bin/echo "OSVersion is $OSVersion"
         if [ "$OSVersion" = "$version" ]; then


### PR DESCRIPTION
Hi, 

- Improve to execute 'startosinstall' with variables as arguments safely.
- To prevent ignorable error messages from being output, use 'mkdir' with '-p'.