### PR TITLE
Fixed example syntax

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -64,7 +64,7 @@
 OSInstaller="$4"
 
 ##Version of Installer OS. Use Parameter 5 in the JSS, or specify here.
-##Example Command: /usr/libexec/PlistBuddy -c 'Print :"System Image Info":version' "/Applications/Install\ macOS\ High\ Sierra.app/Contents/SharedSupport/InstallInfo.plistr"
+##Example Command: /usr/libexec/PlistBuddy -c 'Print :"System Image Info":version' "/Applications/Install macOS High Sierra.app/Contents/SharedSupport/InstallInfo.plist"
 ##Example: 10.12.5
 version="$5"
 versionMajor=$( /bin/echo "$version" | /usr/bin/awk -F. '{print $2}' )


### PR DESCRIPTION
PlistBuddy command example for Installer OS version didn't quite work (typo and combination of "s and \s for path).

I'm working on Mojave upgrade from High Sierra; but, I left the example for the previous versions. What I'm actually using is: `/usr/libexec/PlistBuddy -c 'Print :"System Image Info":"version"' "/Applications/Install macOS Mojave.app/Contents/SharedSupport/InstallInfo.plist"`. Result is: `10.14`.