### PR TITLE
Admin Dialog Fix

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -301,6 +301,10 @@ fi
 exit 0
 EOL
 
+##Set the permission on the file just made.
+/usr/sbin/chown root:admin /usr/local/jamfps/finishOSInstall.sh
+/bin/chmod 755 /usr/local/jamfps/finishOSInstall.sh
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # LAUNCH DAEMON
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -197,12 +197,14 @@ currentUserHomeDirectory=$( /usr/bin/dscl . -read "/users/$currentUser" NFSHomeD
 fvStatus=$( /usr/bin/fdesetup status | head -1 )
 
 ##Check if current user is an admin
-/usr/bin/dscl . read /Groups/admin GroupMembership | grep -i "$currentUser"
+/usr/bin/dscl . read /Groups/admin GroupMembership |  tr ' ' '\n' | grep -x "$currentUser"
 if [[ $? -ne 0 ]] ; then
-	/bin/echo "User is not an Admin.  Adding $currentUser to Admin group"
-	/usr/sbin/dseditgroup -o edit -a "$currentUser" -t user admin
-	/bin/echo "Demote token file added for $currentUser at $currentUserHomeDirectory/.demoteafterupgrade"
-	/usr/bin/touch "$currentUserHomeDirectory"/.demoteafterupgrade
+	if [[ "$fvStatus" == "FileVault is On." ]] ; then
+		/bin/echo "FV is on and OS User is not an Admin.  Adding $currentUser to Admin group"
+		/usr/sbin/dseditgroup -o edit -a "$currentUser" -t user admin
+		/bin/echo "Demote token file added for $currentUser at $currentUserHomeDirectory/.demoteafterupgrade"
+		/usr/bin/touch "$currentUserHomeDirectory"/.demoteafterupgrade
+	fi
 fi
 
 ##Check if device is on battery or ac power

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -199,7 +199,7 @@ currentUserHomeDirectory=$( /usr/bin/dscl . -read "/users/$currentUser" NFSHomeD
 fvStatus=$( /usr/bin/fdesetup status | head -1 )
 
 ##Check if current user is an admin, and if not and FV is on add them to Group 80
-if ! /usr/bin/dscl . read /Groups/admin GroupMembership |  tr ' ' '\n' | grep -x "$currentUser" &>/dev/null ; then ; then
+if ! /usr/bin/dscl . read /Groups/admin GroupMembership |  tr ' ' '\n' | grep -x "$currentUser" &>/dev/null ; then
 	if [[ "$fvStatus" == "FileVault is On." ]] ; then
 		/bin/echo "FV is on and OS User is not an Admin.  Adding $currentUser to Admin group"
 		/usr/sbin/dseditgroup -o edit -a "$currentUser" -t user admin

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -292,7 +292,7 @@ fi
 /bin/rm -fr /usr/local/jamfps
 ##Demote if user was not an admin before upgrade
 ##Get Current User
-currentUser=$( /usr/bin/stat -f %Su /dev/console )
+currentUser=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
 ##Get Current Users homefolder
 currentUserHomeDirectory=$( /usr/bin/dscl . -read "/users/$currentUser" NFSHomeDirectory | cut -d " " -f 2 )
 if [[ -e "$currentUserHomeDirectory"/.demoteafterupgrade ]] ; then

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -275,11 +275,11 @@ fi
 ## Remove Script
 /bin/rm -fr /usr/local/jamfps
 ##Demote if user was not an admin before upgrade
-if [[ -e /Users/Shared/demoteafterupgrade ]] ; then
-	demoteUser=$( /bin/cat /Users/Shared/demoteafterupgrade | head -n1 )
+if [[ -e /Users/Shared/.demoteafterupgrade ]] ; then
+	demoteUser=$( /bin/cat /Users/Shared/.demoteafterupgrade | head -n1 )
 	/bin/echo "User was not an Admin before upgrade, Removing $demoteUser from Admin group"
 	/usr/sbin/dseditgroup -o edit -d "$demoteUser" -t user admin
-	rm -f /Users/Shared/demoteafterupgrade
+	rm -f /Users/Shared/.demoteafterupgrade
 fi	
 exit 0
 EOL
@@ -377,8 +377,8 @@ if [[ ${pwrStatus} == "OK" ]] && [[ ${spaceStatus} == "OK" ]]; then
 		if [[ "$fvStatus" == "FileVault is On." ]] ; then
 			/bin/echo "FV is on and OS User is not an Admin.  Adding $currentUser to Admin group"
 			/usr/sbin/dseditgroup -o edit -a "$currentUser" -t user admin
-			/bin/echo "Demote token file added for $currentUser at /Users/Shared/demoteafterupgrade"
-			echo "$currentUser" > /Users/Shared/demoteafterupgrade
+			/bin/echo "Demote token file added for $currentUser at /Users/Shared/.demoteafterupgrade"
+			echo "$currentUser" > /Users/Shared/.demoteafterupgrade
 		fi
 	fi
     ##Load LaunchAgent


### PR DESCRIPTION
Makes current user admin if FV2 and APFS is on and user is not admin, then demotes the user after the upgrade is complete.  Does not need a user logged in for the demote to work