### PR TITLE
Cleanup unnecessary OSInstaller

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -173,6 +173,20 @@ verifyChecksum() {
     fi
 }
 
+cleanupUnnecessaryOSInstaller() {
+    ignoreOSInstaller="$1"
+
+    IFS_BACKUP=$IFS
+    IFS=$'\n'
+    for removingOSInstaller in $(/usr/bin/find -E /Applications -type d -regex "^/Applications/Install macOS.*\.app" | /usr/bin/grep -v "$ignoreOSInstaller"); do
+        /bin/echo "Removing $removingOSInstaller ..."
+        /bin/rm -rf "$removingOSInstaller"
+    done
+
+    IFS=$IFS_BACKUP
+    return
+}
+
 cleanExit() {
     /bin/kill "${caffeinatePID}"
     exit "$1"
@@ -352,6 +366,7 @@ EOP
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 if [[ ${pwrStatus} == "OK" ]] && [[ ${spaceStatus} == "OK" ]]; then
+    cleanupUnnecessaryOSInstaller "$OSInstaller"
     ##Launch jamfHelper
     if [ ${userDialog} -eq 0 ]; then
         /bin/echo "Launching jamfHelper as FullScreen..."


### PR DESCRIPTION
Apple will often automatically download installer to `/Applications` directory.

* If we want to upgrade to mojave when the machine has sierra and it may have high sierra installer and mojave installer, the high sierra installer will stay on the machine.
* If we want to upgrade to high sierra when the machine has sierra and it has high sierra installer and mojave installer, the machine will upgrade to mojave.
  * It seems that it does not happen reliably.

In order to reduce uncertainties, I decided to delete unnecessary os installers.