### PR TITLE
Cancel auth reboot

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -35,7 +35,7 @@
 # as well as to address changes Apple has made to the ability to complete macOS upgrades
 # silently.
 #
-# VERSION: v2.7.2.2
+# VERSION: v2.7.3
 #
 # REQUIREMENTS:
 #           - Jamf Pro
@@ -51,7 +51,7 @@
 # Written by: Joshua Roskos | Jamf
 #
 # Created On: January 5th, 2017
-# Updated On: October 16th, 2018
+# Updated On: Febrary 18th, 2019
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -108,6 +108,11 @@ fi
 ##Use Parameter 9 in the JSS.
 userDialog="$9"
 if [[ ${userDialog:=0} != 1 ]]; then userDialog=0 ; fi
+
+##Enter 1 (or not 0) for cancel Filevault authenticated reboots, 0 for try to Filevault authenticated reboots(Default)
+##Use Parameter 10 in the JSS.
+cancelFVAuthReboot="${10}"
+if [[ ${cancelFVAuthReboot:=0} != 0 ]]; then cancelFVAuthReboot=1 ; fi
 
 ##Title of OS
 macOSname=$(/bin/echo "$OSInstaller" | /usr/bin/sed -E 's/(.+)?Install(.+)\.app\/?/\2/' | /usr/bin/xargs)
@@ -309,15 +314,15 @@ EOF
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # LAUNCH AGENT FOR FILEVAULT AUTHENTICATED REBOOTS
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+if [ "$cancelFVAuthReboot" = 'no' ]; then
+    ##Determine Program Argument
+    if [[ $osMajor -ge 11 ]]; then
+        progArgument="osinstallersetupd"
+    elif [[ $osMajor -eq 10 ]]; then
+        progArgument="osinstallersetupplaind"
+    fi
 
-##Determine Program Argument
-if [[ $osMajor -ge 11 ]]; then
-    progArgument="osinstallersetupd"
-elif [[ $osMajor -eq 10 ]]; then
-    progArgument="osinstallersetupplaind"
-fi
-
-/bin/cat << EOP > /Library/LaunchAgents/com.apple.install.osinstallersetupd.plist
+    /bin/cat << EOP > /Library/LaunchAgents/com.apple.install.osinstallersetupd.plist
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -343,9 +348,10 @@ fi
 </plist>
 EOP
 
-##Set the permission on the file just made.
-/usr/sbin/chown root:wheel /Library/LaunchAgents/com.apple.install.osinstallersetupd.plist
-/bin/chmod 644 /Library/LaunchAgents/com.apple.install.osinstallersetupd.plist
+    ##Set the permission on the file just made.
+    /usr/sbin/chown root:wheel /Library/LaunchAgents/com.apple.install.osinstallersetupd.plist
+    /bin/chmod 644 /Library/LaunchAgents/com.apple.install.osinstallersetupd.plist
+fi
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # APPLICATION
@@ -363,7 +369,9 @@ if [[ ${pwrStatus} == "OK" ]] && [[ ${spaceStatus} == "OK" ]]; then
         jamfHelperPID=$!
     fi
     ##Load LaunchAgent
-    if [[ ${fvStatus} == "FileVault is On." ]] && [[ ${currentUser} != "root" ]]; then
+    if [[ ${fvStatus} == "FileVault is On." ]] && \
+       [[ ${currentUser} != "root" ]] && \
+       [[ ${cancelFVAuthReboot} -eq 0 ]] ; then
         userID=$( /usr/bin/id -u "${currentUser}" )
         /bin/launchctl bootstrap gui/"${userID}" /Library/LaunchAgents/com.apple.install.osinstallersetupd.plist
     fi

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -35,7 +35,7 @@
 # as well as to address changes Apple has made to the ability to complete macOS upgrades
 # silently.
 #
-# VERSION: v2.7.2.4
+# VERSION: v2.7.2.3
 #
 # REQUIREMENTS:
 #           - Jamf Pro

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -35,7 +35,7 @@
 # as well as to address changes Apple has made to the ability to complete macOS upgrades
 # silently.
 #
-# VERSION: v2.7.3
+# VERSION: v2.7.2.3
 #
 # REQUIREMENTS:
 #           - Jamf Pro
@@ -51,7 +51,7 @@
 # Written by: Joshua Roskos | Jamf
 #
 # Created On: January 5th, 2017
-# Updated On: Febrary 18th, 2019
+# Updated On: March 16th, 2019
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -333,14 +333,7 @@ if [ "$cancelFVAuthReboot" = 'no' ]; then
         progArgument="osinstallersetupplaind"
     fi
 
-##Determine Program Argument
-if [[ $osMajor -ge 11 ]]; then
-    progArgument="osinstallersetupd"
-elif [[ $osMajor -eq 10 ]]; then
-    progArgument="osinstallersetupplaind"
-fi
-
-/bin/cat << EOP > "$osinstallersetupdAgentSettingsFilePath"
+    /bin/cat << EOP > "$osinstallersetupdAgentSettingsFilePath"
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -366,9 +359,11 @@ fi
 </plist>
 EOP
 
-##Set the permission on the file just made.
-/usr/sbin/chown root:wheel "$osinstallersetupdAgentSettingsFilePath"
-/bin/chmod 644 "$osinstallersetupdAgentSettingsFilePath"
+    ##Set the permission on the file just made.
+    /usr/sbin/chown root:wheel "$osinstallersetupdAgentSettingsFilePath"
+    /bin/chmod 644 "$osinstallersetupdAgentSettingsFilePath"
+
+fi
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # APPLICATION

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -35,7 +35,7 @@
 # as well as to address changes Apple has made to the ability to complete macOS upgrades
 # silently.
 #
-# VERSION: v2.7.2.3
+# VERSION: v2.7.2.4
 #
 # REQUIREMENTS:
 #           - Jamf Pro
@@ -51,7 +51,7 @@
 # Written by: Joshua Roskos | Jamf
 #
 # Created On: January 5th, 2017
-# Updated On: March 18th, 2019
+# Updated On: March 19th, 2019
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -35,7 +35,7 @@
 # as well as to address changes Apple has made to the ability to complete macOS upgrades
 # silently.
 #
-# VERSION: v2.7.2.3
+# VERSION: v2.7.2.4
 #
 # REQUIREMENTS:
 #           - Jamf Pro
@@ -51,7 +51,7 @@
 # Written by: Joshua Roskos | Jamf
 #
 # Created On: January 5th, 2017
-# Updated On: March 16th, 2019
+# Updated On: March 18th, 2019
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -369,7 +369,38 @@ fi
 # APPLICATION
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-if ! [[ ${pwrStatus} == "OK" ]] && [[ ${spaceStatus} == "OK" ]]; then
+if [[ ${pwrStatus} == "OK" ]] && [[ ${spaceStatus} == "OK" ]]; then
+    ##Launch jamfHelper
+    if [ ${userDialog} -eq 0 ]; then
+        /bin/echo "Launching jamfHelper as FullScreen..."
+        /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType fs -title "" -icon "$icon" -heading "$heading" -description "$description" &
+        jamfHelperPID=$!
+    else
+        /bin/echo "Launching jamfHelper as Utility Window..."
+        /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "$title" -icon "$icon" -heading "$heading" -description "$description" -iconSize 100 &
+        jamfHelperPID=$!
+    fi
+    ##Load LaunchAgent
+    if [[ ${fvStatus} == "FileVault is On." ]] && [[ ${currentUser} != "root" ]]; then
+        userID=$( /usr/bin/id -u "${currentUser}" )
+        /bin/launchctl bootstrap gui/"${userID}" "$osinstallersetupdAgentSettingsFilePath"
+    fi
+    ##Begin Upgrade
+    /bin/echo "Launching startosinstall..."
+    ##Check if eraseInstall is Enabled
+    if [[ $eraseInstall == 1 ]]; then
+        eraseopt='--eraseinstall'
+        /bin/echo "   Script is configured for Erase and Install of macOS."
+    fi
+
+    osinstallLogfile="/var/log/startosinstall.log"
+    if [ "$versionMajor" -ge 14 ]; then
+        eval /usr/bin/nohup "\"$OSInstaller/Contents/Resources/startosinstall\"" "$eraseopt" --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" >> "$osinstallLogfile" &
+    else
+        eval /usr/bin/nohup "\"$OSInstaller/Contents/Resources/startosinstall\"" "$eraseopt" --applicationpath "\"$OSInstaller\"" --agreetolicense --nointeraction --pidtosignal "$jamfHelperPID" >> "$osinstallLogfile" &
+    fi
+    /bin/sleep 3
+else
     ## Remove Script
     /bin/rm -f "$finishOSInstallScriptFilePath"
     /bin/rm -f "$osinstallersetupdDaemonSettingsFilePath"


### PR DESCRIPTION
Primary subject of this PR is to add "cancel auth reboot" switch. 
In some case, during upgrade OS by non-administaror user face to require to enter administrator credential. I know there are some discussions in Issues. 
I think if auth reboot is not important for your organization like our organization, it should be switch to cancel it. It works as a workaround. 
When computer get reboot after updated os, user must enter its password for continue pre-boot sequence. Just it. 