### PR TITLE
Allow user the opportunity to connect to AC power, plus others

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -173,6 +173,8 @@ kill_process() {
 }
 
 wait_for_ac_power() {
+    local jamfHelperPowerPID
+    jamfHelperPowerPID="$1"
     # Loop for "acPowerWaitTimer" seconds until either AC Power is detected or the timer is up
     /bin/echo "Waiting for AC power..."
     while [[ "$acPowerWaitTimer" -gt "0" ]]; do
@@ -210,8 +212,7 @@ validate_power_status() {
     else
         if [[ "$acPowerWaitTimer" -gt 0 ]]; then
             /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "Waiting for AC Power Connection" -icon "$warnIcon" -description "Please connect your computer to power using an AC power adapter. This process will continue once AC power is detected." &
-            jamfHelperPowerPID=$!
-            wait_for_ac_power
+            wait_for_ac_power "$!"
         else
             sysRequirementErrors+=("• Is connected to AC power")
             /bin/echo "Power Check: ERROR - No AC Power Detected"

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -187,7 +187,7 @@ wait_for_ac_power() {
         ((acPowerWaitTimer--))
     done
     kill_process "$jamfHelperPowerPID"
-    sysRequirementErrors+=("• Is connected to AC power")
+    sysRequirementErrors+=("Is connected to AC power")
     /bin/echo "Power Check: ERROR - No AC Power Detected"
 }
 
@@ -214,7 +214,7 @@ validate_power_status() {
             /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "Waiting for AC Power Connection" -icon "$warnIcon" -description "Please connect your computer to power using an AC power adapter. This process will continue once AC power is detected." &
             wait_for_ac_power "$!"
         else
-            sysRequirementErrors+=("• Is connected to AC power")
+            sysRequirementErrors+=("Is connected to AC power")
             /bin/echo "Power Check: ERROR - No AC Power Detected"
         fi
     fi
@@ -233,7 +233,7 @@ validate_free_space() {
     if [[ ${freeSpace%.*} -ge 15000000000 ]]; then
         /bin/echo "Disk Check: OK - ${freeSpace%.*} Bytes Free Space Detected"
     else
-        sysRequirementErrors+=("• Has at least 15GB of Free Space")
+        sysRequirementErrors+=("Has at least 15GB of Free Space")
         /bin/echo "Disk Check: ERROR - ${freeSpace%.*} Bytes Free Space Detected"
     fi
 }
@@ -291,7 +291,7 @@ if [[ "${#sysRequirementErrors[@]}" -ge 1 ]]; then
     /bin/echo "Launching jamfHelper Dialog (Requirements Not Met)..."
     /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "$title" -icon "$errorIcon" -heading "Requirements Not Met" -description "We were unable to prepare your computer for $macOSname. Please ensure your computer meets the following requirements:
 
-$( /usr/bin/printf '\t%s\n' "${sysRequirementErrors[@]}" )
+$( /usr/bin/printf '\t• %s\n' "${sysRequirementErrors[@]}" )
 
 If you continue to experience this issue, please contact the IT Support Center." -iconSize 100 -button1 "OK" -defaultButton 1
 

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -173,13 +173,13 @@ wait_for_ac_power() {
     while [[ "$acPowerWaitTimer" -gt "0" ]]; do
         if /usr/bin/pmset -g ps | grep "AC Power" > /dev/null ; then
             /bin/echo "Power Check: OK - AC Power Detected"
-            ps -p "$jamfHelperPID" > /dev/null && kill "$jamfHelperPID"; wait "$jamfHelperPID" 2>/dev/null
+            ps -p "$jamfHelperPowerPID" > /dev/null && kill "$jamfHelperPowerPID"; wait "$jamfHelperPowerPID" 2>/dev/null
             return
         fi
         sleep 1
         ((acPowerWaitTimer--))
     done
-    ps -p "$jamfHelperPID" > /dev/null && kill "$jamfHelperPID"; wait "$jamfHelperPID" 2>/dev/null
+    ps -p "$jamfHelperPowerPID" > /dev/null && kill "$jamfHelperPowerPID"; wait "$jamfHelperPowerPID" 2>/dev/null
     sysRequirementErrors+=("• Is connected to AC power")
     /bin/echo "Power Check: ERROR - No AC Power Detected"
 }
@@ -204,7 +204,7 @@ get_power_status() {
         /bin/echo "Power Check: OK - AC Power Detected"
     else
         /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "Waiting for AC Power Connection" -icon "$warnIcon" -description "Please connect your computer to power using an AC power adapter. This process will continue once AC power is detected." &
-        jamfHelperPID=$(/bin/echo $!)
+        jamfHelperPowerPID=$(/bin/echo $!)
         wait_for_ac_power
     fi
 }
@@ -250,7 +250,6 @@ verifyChecksum() {
 
 cleanExit() {
     ps -p "$caffeinatePID" > /dev/null && kill "$caffeinatePID"; wait "$caffeinatePID" 2>/dev/null
-    # /bin/kill "${caffeinatePID}"
     ## Remove Script
     /bin/rm -f "$finishOSInstallScriptFilePath" 2>/dev/null
     /bin/rm -f "$osinstallersetupdDaemonSettingsFilePath" 2>/dev/null
@@ -421,9 +420,6 @@ fi
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # APPLICATION
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-
-##Check that the system requirements are met before doing anything else
-verify_system_requirements
 
 ##Launch jamfHelper
 if [ ${userDialog} -eq 0 ]; then

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -153,9 +153,36 @@ osinstallersetupdDaemonSettingsFilePath="/Library/LaunchDaemons/com.jamfps.clean
 ##Launch agent settings for filevault authenticated reboots
 osinstallersetupdAgentSettingsFilePath="/Library/LaunchAgents/com.apple.install.osinstallersetupd.plist"
 
+##Amount of time (in seconds) to allow a user to connect to AC power before moving on
+acPowerWaitTimer="120"
+
+##Icon to display during the AC Power warning
+warnIcon="/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertCautionIcon.icns"
+
+##Icon to display when errors are found
+errorIcon="/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertStopIcon.icns"
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # FUNCTIONS
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+wait_for_ac_power() {
+    # Loop for 120 seconds until either AC Power is detected or the timer is up
+    sysRequirementErrors=()
+    /bin/echo "Waiting for AC power..."
+    while [[ "$acPowerWaitTimer" -gt "0" ]]; do
+        if /usr/bin/pmset -g ps | grep "AC Power" > /dev/null ; then
+            /bin/echo "Power Check: OK - AC Power Detected"
+            ps -p "$jamfHelperPID" > /dev/null && kill "$jamfHelperPID"; wait "$jamfHelperPID" 2>/dev/null
+            return
+        fi
+        sleep 1
+        ((acPowerWaitTimer--))
+    done
+    ps -p "$jamfHelperPID" > /dev/null && kill "$jamfHelperPID"; wait "$jamfHelperPID" 2>/dev/null
+    sysRequirementErrors+=("• Is connected to AC power")
+    /bin/echo "Power Check: ERROR - No AC Power Detected"
+}
 
 downloadInstaller() {
     /bin/echo "Downloading macOS Installer..."
@@ -168,6 +195,36 @@ downloadInstaller() {
     /usr/local/jamf/bin/jamf policy -event "$download_trigger"
     ##Kill Jamf Helper HUD post download
     /bin/kill "${jamfHUDPID}"
+}
+
+get_power_status() {
+    ##Check if device is on battery or ac power
+    ##If not allow user to connect to power for specified time period
+    if /usr/bin/pmset -g ps | grep "AC Power" > /dev/null ; then
+        /bin/echo "Power Check: OK - AC Power Detected"
+    else
+        /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "Waiting for AC Power Connection" -icon "$warnIcon" -description "Please connect your computer to power using an AC power adapter. This process will continue once AC power is detected." &
+        jamfHelperPID=$(/bin/echo $!)
+        wait_for_ac_power
+    fi
+}
+
+get_free_space() {
+    ##Check if free space > 15GB
+    osMajor=$( /usr/bin/sw_vers -productVersion | /usr/bin/awk -F. '{print $2}' )
+    osMinor=$( /usr/bin/sw_vers -productVersion | /usr/bin/awk -F. '{print $3}' )
+    if [[ $osMajor -eq 12 ]] || [[ $osMajor -eq 13 && $osMinor -lt 4 ]]; then
+        freeSpace=$( /usr/sbin/diskutil info / | /usr/bin/grep "Available Space" | /usr/bin/awk '{print $6}' | /usr/bin/cut -c 2- )
+    else
+        freeSpace=$( /usr/sbin/diskutil info / | /usr/bin/grep "Free Space" | /usr/bin/awk '{print $6}' | /usr/bin/cut -c 2- )
+    fi
+
+    if [[ ${freeSpace%.*} -ge 15000000000 ]]; then
+        /bin/echo "Disk Check: OK - ${freeSpace%.*} Bytes Free Space Detected"
+    else
+        sysRequirementErrors+=("• Has at least 15GB of Free Space")
+        /bin/echo "Disk Check: ERROR - ${freeSpace%.*} Bytes Free Space Detected"
+    fi
 }
 
 verifyChecksum() {
@@ -192,7 +249,12 @@ verifyChecksum() {
 }
 
 cleanExit() {
-    /bin/kill "${caffeinatePID}"
+    ps -p "$caffeinatePID" > /dev/null && kill "$caffeinatePID"; wait "$caffeinatePID" 2>/dev/null
+    # /bin/kill "${caffeinatePID}"
+    ## Remove Script
+    /bin/rm -f "$finishOSInstallScriptFilePath" 2>/dev/null
+    /bin/rm -f "$osinstallersetupdDaemonSettingsFilePath" 2>/dev/null
+    /bin/rm -f "$osinstallersetupdAgentSettingsFilePath" 2>/dev/null
     exit "$1"
 }
 
@@ -210,31 +272,20 @@ currentUser=$( /usr/bin/stat -f %Su /dev/console )
 ##Check if FileVault Enabled
 fvStatus=$( /usr/bin/fdesetup status | head -1 )
 
-##Check if device is on battery or ac power
-pwrAdapter=$( /usr/bin/pmset -g ps )
-if [[ ${pwrAdapter} == *"AC Power"* ]]; then
-    pwrStatus="OK"
-    /bin/echo "Power Check: OK - AC Power Detected"
-else
-    pwrStatus="ERROR"
-    /bin/echo "Power Check: ERROR - No AC Power Detected"
-fi
+##Run system requirement checks
+get_power_status
+get_free_space
 
-##Check if free space > 15GB
-osMajor=$( /usr/bin/sw_vers -productVersion | /usr/bin/awk -F. '{print $2}' )
-osMinor=$( /usr/bin/sw_vers -productVersion | /usr/bin/awk -F. '{print $3}' )
-if [[ $osMajor -eq 12 ]] || [[ $osMajor -eq 13 && $osMinor -lt 4 ]]; then
-    freeSpace=$( /usr/sbin/diskutil info / | /usr/bin/grep "Available Space" | /usr/bin/awk '{print $6}' | /usr/bin/cut -c 2- )
-else
-    freeSpace=$( /usr/sbin/diskutil info / | /usr/bin/grep "Free Space" | /usr/bin/awk '{print $6}' | /usr/bin/cut -c 2- )
-fi
+##Don't waste the users time, exit here if system requirements are not met
+if [[ "${#sysRequirementErrors[@]}" -ge 1 ]]; then
+    /bin/echo "Launching jamfHelper Dialog (Requirements Not Met)..."
+    /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "$title" -icon "$errorIcon" -heading "Requirements Not Met" -description "We were unable to prepare your computer for $macOSname. Please ensure your computer meets the following requirements:
 
-if [[ ${freeSpace%.*} -ge 15000000000 ]]; then
-    spaceStatus="OK"
-    /bin/echo "Disk Check: OK - ${freeSpace%.*} Bytes Free Space Detected"
-else
-    spaceStatus="ERROR"
-    /bin/echo "Disk Check: ERROR - ${freeSpace%.*} Bytes Free Space Detected"
+$( printf '\t%s\n' "${sysRequirementErrors[@]}" )
+
+If you continue to experience this issue, please contact the IT Support Center." -iconSize 100 -button1 "OK" -defaultButton 1
+
+    cleanExit 1
 fi
 
 ##Check for existing OS installer
@@ -245,14 +296,14 @@ while [[ $loopCount -lt 3 ]]; do
         OSVersion=$(/usr/libexec/PlistBuddy -c 'Print :"System Image Info":version' "$OSInstaller/Contents/SharedSupport/InstallInfo.plist")
         /bin/echo "OSVersion is $OSVersion"
         if [ "$OSVersion" = "$version" ]; then
-          /bin/echo "Installer found, version matches. Verifying checksum..."
-          verifyChecksum
+            /bin/echo "Installer found, version matches. Verifying checksum..."
+            verifyChecksum
         else
-          ##Delete old version.
-          /bin/echo "Installer found, but old. Deleting..."
-          /bin/rm -rf "$OSInstaller"
-          /bin/sleep 2
-          downloadInstaller
+            ##Delete old version.
+            /bin/echo "Installer found, but old. Deleting..."
+            /bin/rm -rf "$OSInstaller"
+            /bin/sleep 2
+            downloadInstaller
         fi
         if [ "$validChecksum" == 1 ]; then
             unsuccessfulDownload=0
@@ -261,7 +312,6 @@ while [[ $loopCount -lt 3 ]]; do
     else
         downloadInstaller
     fi
-
     unsuccessfulDownload=1
     ((loopCount++))
 done
@@ -269,10 +319,9 @@ done
 if (( unsuccessfulDownload == 1 )); then
     /bin/echo "macOS Installer Downloaded 3 Times - Checksum is Not Valid"
     /bin/echo "Prompting user for error and exiting..."
-    /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "$title" -icon "$icon" -heading "Error Downloading $macOSname" -description "We were unable to prepare your computer for $macOSname. Please contact the IT Support Center." -iconSize 100 -button1 "OK" -defaultButton 1
+    /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "$title" -icon "$errorIcon" -heading "Error Downloading $macOSname" -description "We were unable to prepare your computer for $macOSname. Please contact the IT Support Center." -iconSize 100 -button1 "OK" -defaultButton 1
     cleanExit 0
 fi
-
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # CREATE FIRST BOOT SCRIPT
@@ -373,19 +422,8 @@ fi
 # APPLICATION
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-if ! [[ ${pwrStatus} == "OK" ]] && [[ ${spaceStatus} == "OK" ]]; then
-    ## Remove Script
-    /bin/rm -f "$finishOSInstallScriptFilePath"
-    /bin/rm -f "$osinstallersetupdDaemonSettingsFilePath"
-    /bin/rm -f "$osinstallersetupdAgentSettingsFilePath"
-
-    /bin/echo "Launching jamfHelper Dialog (Requirements Not Met)..."
-    /Library/Application\ Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper -windowType utility -title "$title" -icon "$icon" -heading "Requirements Not Met" -description "We were unable to prepare your computer for $macOSname. Please ensure you are connected to power and that you have at least 15GB of Free Space.
-
-    If you continue to experience this issue, please contact the IT Support Center." -iconSize 100 -button1 "OK" -defaultButton 1
-
-    cleanExit 1
-fi
+##Check that the system requirements are met before doing anything else
+verify_system_requirements
 
 ##Launch jamfHelper
 if [ ${userDialog} -eq 0 ]; then


### PR DESCRIPTION
Most of my users will read the instructions, and still run the policy even though AC power is not connected. This PR allows a user to connect to AC power within a specified time period, and will automatically continue once AC power is connected. Also, when a system requirement is not met, the jamfHelper will display the EXACT system requirement that is not met, rather than a list of which ones might not be met. Additionally, it does not make sense to me to continue downloading the installer and creating files on the system if those requirements are not met, so this PR will exit if the system requirements are not met, thus the users time is not wasted and actions are not taken when not necessary.

Here is a list of some things included:
- Allows the user a specified time period to connect to AC power before quitting
- Automatically detect that AC power is connected during the specified time period
- Exits if system requirements are not met, so that the users time is not wasted doing the other tasks like downloading the installer
- Displays the EXACT system requirement that is not met, rather than giving showing them both which might not be accurate
- Uses system icons for some jamfHelper dialogs as the icon in the OS Installer might not be present if the installer does not exist locally
- Moved clean up tasks to the cleanExit function and suppress errors if the caffeinatePID is not found or any scripts do not exist