### PR TITLE
Optimize finish OS install script

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -344,7 +344,6 @@ fi
 ## First Run Script to remove the installer.
 ## Clean up files
 /bin/rm -fr "$OSInstaller"
-/bin/sleep 2
 ## Update Device Inventory
 /usr/local/jamf/bin/jamf recon
 ## Remove LaunchAgent and LaunchDaemon


### PR DESCRIPTION
I delete the `sleep` command of finish OS install script because it is not necessary.
