### PR TITLE
The macOSUpgrade.sh is only interested in the installer version, not the current device os

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -237,7 +237,7 @@ validate_free_space() {
     ## 10.13.4 or later, diskutil info has 'Free Space'.
     freeSpace=$( /usr/sbin/diskutil info / | /usr/bin/grep -E "(Available Space)|(Free Space)" | /usr/bin/awk '{print $6}' | /usr/bin/cut -c 2- )
 
-    ## Check if free space > 15GB (10.13) or 20GB (10.14+)
+    ## Check if free space > 15GB (install 10.13) or 20GB (install 10.14+)
     requiredDiskSpaceSizeGB=$([ "$installerMajor" -ge 14 ] && /bin/echo "20" || /bin/echo "15")
     if [[ ${freeSpace%.*} -ge $(( requiredDiskSpaceSizeGB * 1000 * 1000 * 1000 )) ]]; then
         /bin/echo "Disk Check: OK - ${freeSpace%.*} Bytes Free Space Detected"

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -315,7 +315,7 @@ while [ "$loopCount" -lt 3 ]; do
     if [ -e "$OSInstaller" ]; then
         /bin/echo "$OSInstaller found, checking version."
         currentInstallerVersion=$(/usr/libexec/PlistBuddy -c 'Print :"System Image Info":version' "$OSInstaller/Contents/SharedSupport/InstallInfo.plist")
-        /bin/echo "OSVersion is $currentInstallerVersion"
+        /bin/echo "Found macOS installer for version $currentInstallerVersion."
         if [ "$currentInstallerVersion" = "$installerVersion" ]; then
             /bin/echo "Installer found, version matches. Verifying checksum..."
             verifyChecksum


### PR DESCRIPTION
The change in https://github.com/kc9wwh/macOSUpgrade/pull/115 caused a misinterpretation of the meaning of version.

The macOSUpgrade.sh is only interested in the installer version, not the current device OS.