### PR TITLE
Update macOSUpgrade.sh

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -240,8 +240,9 @@ validate_free_space() {
 
     diskInfoPlist=$(/usr/sbin/diskutil info -plist /)
     ## 10.13.4 or later, diskutil info command output changes key from 'AvailableSpace' to 'Free Space' about disk space.
+    ## 10.15.0 or later, diskutil info command output changes key from 'APFSContainerFree' to 'Free Space' about disk space.
     freeSpace=$(
-    /usr/libexec/PlistBuddy -c "Print :FreeSpace" /dev/stdin <<< "$diskInfoPlist" 2>/dev/null || /usr/libexec/PlistBuddy -c "Print :AvailableSpace" /dev/stdin <<< "$diskInfoPlist" 2>/dev/null
+    /usr/libexec/PlistBuddy -c "Print :APFSContainerFree" /dev/stdin <<< "$diskInfoPlist" 2>/dev/null || /usr/libexec/PlistBuddy -c "Print :FreeSpace" /dev/stdin <<< "$diskInfoPlist" 2>/dev/null || /usr/libexec/PlistBuddy -c "Print :AvailableSpace" /dev/stdin <<< "$diskInfoPlist" 2>/dev/null
     )
 
     ## The free space calculation also includes the installer, so it is excluded.
@@ -502,4 +503,4 @@ eval "$startosinstallCommand"
 
 /bin/sleep 3
 
-cleanExit 0
+exit 0


### PR DESCRIPTION
Changes to free disk space calculation for macOS Catalina. Removed CleanExit function for the end of the script.