### PR TITLE
Add --forcequitapps

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -510,7 +510,7 @@ if [ "$installerVersionMajor" -lt 14 ]; then
     startosinstallOptions+=("--applicationpath \"$OSInstaller\"")
 fi
 
-if [ "installerVersionMajor" -gt 14 ]; then
+if [ "$installerVersionMajor" -gt 14 ]; then
     # The --forcequitapps option will force Self Service to quit, which prevents Self Service from cancelling a restart
     startosinstallOptions+=("--forcequitapps")
 fi

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -510,6 +510,11 @@ if [ "$installerVersionMajor" -lt 14 ]; then
     startosinstallOptions+=("--applicationpath \"$OSInstaller\"")
 fi
 
+if [ "installerVersionMajor" -gt 14 ]; then
+    # The --forcequitapps option will force Self Service to quit, which prevents Self Service from cancelling a restart
+    startosinstallOptions+=("--forcequitapps")
+fi
+
 ## Check if eraseInstall is Enabled
 if [ "$eraseInstall" -eq 1 ]; then
     startosinstallOptions+=("--eraseinstall")


### PR DESCRIPTION
If the installer is for Catalina (or above), add --forcequitapps to the startosinsatllOptions variable, to prevent Self Service from cancelling a restart.