### PR TITLE
Wait for the upgrade to really be done

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -395,6 +395,22 @@ fi
 /bin/cat << EOF > "$finishOSInstallScriptFilePath"
 #!/bin/bash
 ## First Run Script to remove the installer.
+
+## Wait until /var/db/.AppleUpgrade disappears
+while [ -e /var/db/.AppleUpgrade ];
+do
+	echo "\$(date "+%a %h %d %H:%M:%S"): Waiting for /var/db/.AppleUpgrade to disappear."
+    sleep 60
+done
+    
+## Wait until the upgrade process completes
+INSTALLER_PROGRESS_PROCESS=\$(pgrep -l "Installer Progress")
+until [ "\$INSTALLER_PROGRESS_PROCESS" = "" ];
+do
+	echo "\$(date "+%a %h %d %H:%M:%S"): Waiting for Installer Progress to complete."
+    sleep 60
+    INSTALLER_PROGRESS_PROCESS=\$(pgrep -l "Installer Progress")
+done
 ## Clean up files
 /bin/rm -fr "$OSInstaller"
 ## Update Device Inventory

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -390,16 +390,20 @@ fi
 # CREATE FIRST BOOT SCRIPT
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+## Because the parent bash script creates a new bash script using HEREDOC ( this <<EOF >that ),
+## use a backslash before the dollar sign to avoid evaluating the variable (or command) as part of creating the script.
+
 /bin/mkdir -p /usr/local/jamfps
 
 /bin/cat << EOF > "$finishOSInstallScriptFilePath"
 #!/bin/bash
 ## First Run Script to remove the installer.
 
+
 ## Wait until /var/db/.AppleUpgrade disappears
 while [ -e /var/db/.AppleUpgrade ];
 do
-	echo "\$(date "+%a %h %d %H:%M:%S"): Waiting for /var/db/.AppleUpgrade to disappear."
+	echo "\$(date "+%a %h %d %H:%M:%S"): Waiting for /var/db/.AppleUpgrade to disappear." >> /usr/local/jamfps/firstbootupgrade.log
     sleep 60
 done
     
@@ -407,7 +411,7 @@ done
 INSTALLER_PROGRESS_PROCESS=\$(pgrep -l "Installer Progress")
 until [ "\$INSTALLER_PROGRESS_PROCESS" = "" ];
 do
-	echo "\$(date "+%a %h %d %H:%M:%S"): Waiting for Installer Progress to complete."
+	echo "\$(date "+%a %h %d %H:%M:%S"): Waiting for Installer Progress to complete." >> /usr/local/jamfps/firstbootupgrade.log
     sleep 60
     INSTALLER_PROGRESS_PROCESS=\$(pgrep -l "Installer Progress")
 done


### PR DESCRIPTION
After an upgrade, you can log in, but the upgrade isn't done yet. Wait until the upgrade is really done before performing the recon and cleaning up.
Address https://github.com/kc9wwh/macOSUpgrade/issues/141