### PR TITLE
prepare-jamf-policy.sh supports Big Sur.

### DIFF
--- a/helper-tools/prepare-jamf-policy.sh
+++ b/helper-tools/prepare-jamf-policy.sh
@@ -37,26 +37,26 @@ if [ ! -d  "${OSInstaller}/Contents/SharedSupport" ]; then
     exit 1
 fi
 
-if [ -f "${OSInstaller}/Contents/SharedSupport/InstallInfo.plist" ]; then
-    # macOS 10.15 or ealier.
-    plist_type=1015
-    plist="${OSInstaller}/Contents/SharedSupport/InstallInfo.plist"
-elif [ -f "${OSInstaller}/Contents/Info.plist" ]; then
-    # macOS 11.0 or later.
-    plist_type=1100
-    plist="${OSInstaller}/Contents/Info.plist"
-else
-    echo "Not found plist file."
-    echo "Unknown installer type. Apple may change something."
-    exit 1
-fi
-
 if [ -f "${OSInstaller}/Contents/SharedSupport/InstallESD.dmg" ]; then
     # macOS 10.15 or ealier.
     dmg="${OSInstaller}/Contents/SharedSupport/InstallESD.dmg"
+    plist="${OSInstaller}/Contents/SharedSupport/InstallInfo.plist"
+    plist_type=1015
+    if [ ! -f "$plist" ]; then
+        echo "Not found file: $plist"
+        echo "Unknown installer type."
+        exit 1
+    fi
 elif [ -f "${OSInstaller}/Contents/SharedSupport/SharedSupport.dmg" ]; then
     # macOS 11.0 or later.
     dmg="${OSInstaller}/Contents/SharedSupport/SharedSupport.dmg"
+    plist="${OSInstaller}/Contents/Info.plist"
+    plist_type=1100
+    if [ ! -f "$plist" ]; then
+        echo "Not found file: $plist"
+        echo "Unknown installer type."
+        exit 1
+    fi
 else
     echo "Not found dmg file."
     echo "This is not expected installer type."
@@ -68,6 +68,7 @@ if [ "$plist_type" -lt 1100 ]; then
 else
     osversion=$(/usr/libexec/PlistBuddy -c "print DTPlatformVersion" "$plist")
 fi
+
 echo "Wait seconds, getting checksum..."
 checksum=$(/sbin/md5 -r "$dmg" | /usr/bin/awk '{print $1}')
 
@@ -83,23 +84,54 @@ Parameter 7: $checksum
 
 _RESULT
 
-# Build a package of installer
-if [ ! -x /usr/bin/pkgbuild ]; then exit 0; fi
-read -r -p "Would you need a package archive of $( basename "$OSInstaller" )? [y/n]: " ANS
-if [ "$ANS" != y ]; then exit 0 ;fi
-echo "Ok, building package archive file of $( basename "$OSInstaller"). Wait few minutes."
-
-PKGID="macOSUpgrade.helper-tools.pkgbuild"
-PKGFILE="${HOME}/Downloads/$(basename "$OSInstaller" ).${osversion}.pkg"
 workdir="$(/usr/bin/mktemp -d)"
-/bin/mkdir -p "$workdir/root/Applications"
-/bin/cp -a "${OSInstaller%/}" "$workdir/root/Applications"
+if [ "$plist_type" -lt 1100 ]; then
+    # Build a package of installer
+    if [ ! -x /usr/bin/pkgbuild ]; then exit 0; fi
+    read -r -p "Would you need a package archive of $( basename "$OSInstaller" )? [y/n]: " ANS
+    if [ "$ANS" != y ]; then exit 0 ;fi
 
-if [ -f "$PKGFILE" ]; then
-   /bin/mv "${PKGFILE}" "${PKGFILE%.pkg}.previous.$(uuidgen).pkg"
+    echo "Ok, building package archive file of $( basename "$OSInstaller"). Wait few minutes."
+
+    PKGID="macOSUpgrade.helper-tools.pkgbuild"
+    PKGFILE="${HOME}/Downloads/$(basename "$OSInstaller" ).${osversion}.pkg"
+    /bin/mkdir -p "$workdir/root/Applications"
+    /bin/cp -a "${OSInstaller%/}" "$workdir/root/Applications"
+
+    if [ -f "$PKGFILE" ]; then
+        /bin/mv "${PKGFILE}" "${PKGFILE%.pkg}.previous.$(uuidgen).pkg"
+    fi
+
+    if /usr/bin/pkgbuild --identifier "$PKGID" --root "${workdir}/root" "$PKGFILE" > "/tmp/pkgbuid.$( date +%F_%H%M%S ).log" ; then
+        echo "Done. $PKGFILE"
+    else
+        echo "FAILED."
+    fi
+else
+    # https://www.jamf.com/jamf-nation/discussions/37294/package-big-sur-installer-with-composer-issue
+    read -r -p "Would you need a DMG file of $( basename "$OSInstaller" )? [y/n]: " ANS
+    if [ "$ANS" != y ]; then exit 0 ;fi
+
+    echo "Ok, building DMG file of $( basename "$OSInstaller"). Wait few minutes."
+
+    temp_dmg="${workdir}/osinstaller.dmg"
+    dist_dmg="${HOME}/Downloads/$(basename "$OSInstaller" ).${osversion}.dmg"
+    sizeOfInstaller="$( /usr/bin/du -sm "$OSInstaller" | awk '{print $1}' )"
+    volumename="macOSInstaller"
+
+    /usr/bin/hdiutil create -size $(( sizeOfInstaller + 256 ))m -volname "$volumename" "$temp_dmg" -fs APFS > /dev/null
+    devfile="$( /usr/bin/hdiutil attach -readwrite -nobrowse "$temp_dmg" | awk '$NF == "GUID_partition_scheme" {print $1}' )"
+
+    /bin/mkdir "/Volumes/${volumename}/Applications"
+    /bin/cp -a "${OSInstaller%/}" "/Volumes/${volumename}/Applications"
+    /usr/bin/hdiutil detach "$devfile" > /dev/null
+
+    if [ -f "$dist_dmg" ]; then
+        /bin/mv "${dist_dmg}" "${dist_dmg%.dmg}.previous.$(uuidgen).dmg"
+    fi
+
+    /usr/bin/hdiutil convert "$temp_dmg" -format ULFO -o "$dist_dmg" > /dev/null
+
+    echo "Done. $dist_dmg"
 fi
-
-/usr/bin/pkgbuild --identifier "$PKGID" --root "${workdir}/root" "$PKGFILE" > "/tmp/pkgbuid.$( date +%F_%H%M%S ).log"
-
 /bin/rm -rf "$workdir"
-echo "Done. $PKGFILE"

--- a/helper-tools/prepare-jamf-policy.sh
+++ b/helper-tools/prepare-jamf-policy.sh
@@ -84,7 +84,6 @@ Parameter 7: $checksum
 
 _RESULT
 
-workdir="$(/usr/bin/mktemp -d)"
 if [ "$plist_type" -lt 1100 ]; then
     # Build a package of installer
     if [ ! -x /usr/bin/pkgbuild ]; then exit 0; fi
@@ -93,6 +92,7 @@ if [ "$plist_type" -lt 1100 ]; then
 
     echo "Ok, building package archive file of $( basename "$OSInstaller"). Wait few minutes."
 
+    workdir="$(/usr/bin/mktemp -d)"
     PKGID="macOSUpgrade.helper-tools.pkgbuild"
     PKGFILE="${HOME}/Downloads/$(basename "$OSInstaller" ).${osversion}.pkg"
     /bin/mkdir -p "$workdir/root/Applications"
@@ -114,6 +114,7 @@ else
 
     echo "Ok, building DMG file of $( basename "$OSInstaller"). Wait few minutes."
 
+    workdir="$(/usr/bin/mktemp -d)"
     temp_dmg="${workdir}/osinstaller.dmg"
     dist_dmg="${HOME}/Downloads/$(basename "$OSInstaller" ).${osversion}.dmg"
     sizeOfInstaller="$( /usr/bin/du -sm "$OSInstaller" | awk '{print $1}' )"


### PR DESCRIPTION
Fixed #150 

```
% ./helper-tools/prepare-jamf-policy.sh /Applications/Install\ macOS\ Big\ Sur.app
Wait seconds, getting checksum...

=====================================================
Parameters for JamfPro policy:
Parameter 4: /Applications/Install macOS Big Sur.app
Parameter 5: 11.0.1
Parameter 6: (Your download trigger policy)
Parameter 7: 5e17e9fc4186f4ac3adbdc73ddd082ee
=====================================================

Would you need a DMG file of Install macOS Big Sur.app? [y/n]: y
Ok, building DMG file of Install macOS Big Sur.app. Wait few minutes.
Done. /Users/hoi/Downloads/Install macOS Big Sur.app.11.0.1.dmg
```

```
% ./prepare-jamf-policy.sh /Applications/Install\ macOS\ Catalina.app
Wait seconds, getting checksum...

=====================================================
Parameters for JamfPro policy:
Parameter 4: /Applications/Install macOS Catalina.app
Parameter 5: 10.15.7
Parameter 6: (Your download trigger policy)
Parameter 7: 0bc562caacdb67f0f9d3aed6c8ac63c4
=====================================================

Would you need a package archive of Install macOS Catalina.app? [y/n]: y
Ok, building package archive file of Install macOS Catalina.app. Wait few minutes.
Done. /Users/hoi/Downloads/Install macOS Catalina.app.10.15.7.pkg
```