### PR TITLE
Fix checksum handling for Big Sur

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -193,7 +193,7 @@ declare -a startosinstallOptions=()
 binaryNameForOSInstallerSetup=$([ "$installerVersionMajor" -ge 11 ] && /bin/echo "osinstallersetupd" || /bin/echo "osinstallersetupplaind")
 
 ## Determine binary for checksum
-binaryNameForCheckSum=$([ "$installerVersionMajor" -ge 11 ] && /bin/echo "SharedSupport" || /bin/echo "InstallESD")
+binaryNameForCheckSum=$([ "$installerVersionMajor" -ge 11 ] && /bin/echo "InstallESD" || /bin/echo "SharedSupport")
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # FUNCTIONS


### PR DESCRIPTION
Fix checksum handling for Big Sur by checking SharedSupport.dmg instead of InstallESD.dmg if major version greater or equal to 11.