### PR TITLE
workaround for executing on Mojave

### DIFF
--- a/helper-tools/prepare-jamf-policy.sh
+++ b/helper-tools/prepare-jamf-policy.sh
@@ -119,11 +119,10 @@ else
     dist_dmg="${HOME}/Downloads/$(basename "$OSInstaller" ).${osversion}.dmg"
     sizeOfInstaller="$( /usr/bin/du -sm "$OSInstaller" | awk '{print $1}' )"
     volumename="macOSInstaller"
-    extra_size=256
+    extra_size=512
     filesystem=APFS
 
     if [ "$( /usr/bin/sw_vers -productVersion | awk -F. '{ print ($1 * 10 ** 2 +  $2 )}' )" -lt 1015 ]; then
-        extra_size=512
         filesystem='JHFS+'
     fi
 
@@ -131,8 +130,14 @@ else
     devfile="$( /usr/bin/hdiutil attach -readwrite -nobrowse "$temp_dmg" | awk '$NF == "GUID_partition_scheme" {print $1}' )"
 
     /bin/mkdir "/Volumes/${volumename}/Applications"
-    /bin/cp -a "${OSInstaller%/}" "/Volumes/${volumename}/Applications"
-    /usr/bin/hdiutil detach "$devfile" > /dev/null
+    if /bin/cp -a "${OSInstaller%/}" "/Volumes/${volumename}/Applications" ; then
+        /usr/bin/hdiutil detach "$devfile" > /dev/null
+    else
+        echo "=== DEBUG ==="
+        /bin/df -lH
+        echo "temp_dmg: $temp_dmg"
+        exit 1
+    fi
 
     if [ -f "$dist_dmg" ]; then
         /bin/mv "${dist_dmg}" "${dist_dmg%.dmg}.previous.$(uuidgen).dmg"

--- a/helper-tools/prepare-jamf-policy.sh
+++ b/helper-tools/prepare-jamf-policy.sh
@@ -119,8 +119,15 @@ else
     dist_dmg="${HOME}/Downloads/$(basename "$OSInstaller" ).${osversion}.dmg"
     sizeOfInstaller="$( /usr/bin/du -sm "$OSInstaller" | awk '{print $1}' )"
     volumename="macOSInstaller"
+    extra_size=256
+    filesystem=APFS
 
-    /usr/bin/hdiutil create -size $(( sizeOfInstaller + 256 ))m -volname "$volumename" "$temp_dmg" -fs APFS > /dev/null
+    if [ "$( /usr/bin/sw_vers -productVersion | awk -F. '{ print ($1 * 10 ** 2 +  $2 )}' )" -lt 1015 ]; then
+        extra_size=512
+        filesystem='JHFS+'
+    fi
+
+    /usr/bin/hdiutil create -size $(( sizeOfInstaller + extra_size ))m -volname "$volumename" "$temp_dmg" -fs "$filesystem" > /dev/null
     devfile="$( /usr/bin/hdiutil attach -readwrite -nobrowse "$temp_dmg" | awk '$NF == "GUID_partition_scheme" {print $1}' )"
 
     /bin/mkdir "/Volumes/${volumename}/Applications"

--- a/helper-tools/prepare-jamf-policy.sh
+++ b/helper-tools/prepare-jamf-policy.sh
@@ -76,7 +76,7 @@ cat <<_RESULT
 
 =====================================================
 Parameters for JamfPro policy:
-Parameter 4: /Applications/$( basename "$OSInstaller" )
+Parameter 4: /Applications/$( /usr/bin/basename "$OSInstaller" )
 Parameter 5: $osversion
 Parameter 6: (Your download trigger policy)
 Parameter 7: $checksum
@@ -87,14 +87,14 @@ _RESULT
 if [ "$plist_type" -lt 1100 ]; then
     # Build a package of installer
     if [ ! -x /usr/bin/pkgbuild ]; then exit 0; fi
-    read -r -p "Would you need a package archive of $( basename "$OSInstaller" )? [y/n]: " ANS
+    read -r -p "Would you need a package archive of $( /usr/bin/basename "$OSInstaller" )? [y/n]: " ANS
     if [ "$ANS" != y ]; then exit 0 ;fi
 
-    echo "Ok, building package archive file of $( basename "$OSInstaller"). Wait few minutes."
+    echo "Ok, building package archive file of $( /usr/bin/basename "$OSInstaller" ). Wait few minutes."
 
     workdir="$(/usr/bin/mktemp -d)"
     PKGID="macOSUpgrade.helper-tools.pkgbuild"
-    PKGFILE="${HOME}/Downloads/$(basename "$OSInstaller" ).${osversion}.pkg"
+    PKGFILE="${HOME}/Downloads/$( /usr/bin/basename "$OSInstaller" ).${osversion}.pkg"
     /bin/mkdir -p "$workdir/root/Applications"
     /bin/cp -a "${OSInstaller%/}" "$workdir/root/Applications"
 
@@ -102,32 +102,32 @@ if [ "$plist_type" -lt 1100 ]; then
         /bin/mv "${PKGFILE}" "${PKGFILE%.pkg}.previous.$(uuidgen).pkg"
     fi
 
-    if /usr/bin/pkgbuild --identifier "$PKGID" --root "${workdir}/root" "$PKGFILE" > "/tmp/pkgbuid.$( date +%F_%H%M%S ).log" ; then
+    if /usr/bin/pkgbuild --identifier "$PKGID" --root "${workdir}/root" "$PKGFILE" > "/tmp/pkgbuid.$( /bin/date +%F_%H%M%S ).log" ; then
         echo "Done. $PKGFILE"
     else
         echo "FAILED."
     fi
 else
     # https://www.jamf.com/jamf-nation/discussions/37294/package-big-sur-installer-with-composer-issue
-    read -r -p "Would you need a DMG file of $( basename "$OSInstaller" )? [y/n]: " ANS
+    read -r -p "Would you need a DMG file of $( /usr/bin/basename "$OSInstaller" )? [y/n]: " ANS
     if [ "$ANS" != y ]; then exit 0 ;fi
 
-    echo "Ok, building DMG file of $( basename "$OSInstaller"). Wait few minutes."
+    echo "Ok, building DMG file of $( /usr/bin/basename "$OSInstaller" ). Wait few minutes."
 
     workdir="$(/usr/bin/mktemp -d)"
     temp_dmg="${workdir}/osinstaller.dmg"
-    dist_dmg="${HOME}/Downloads/$(basename "$OSInstaller" ).${osversion}.dmg"
-    sizeOfInstaller="$( /usr/bin/du -sm "$OSInstaller" | awk '{print $1}' )"
+    dist_dmg="${HOME}/Downloads/$( /usr/bin/basename "$OSInstaller" ).${osversion}.dmg"
+    sizeOfInstaller="$( /usr/bin/du -sm "$OSInstaller" | /usr/bin/awk '{print $1}' )"
     volumename="macOSInstaller"
     extra_size=512
-    filesystem=APFS
+    filesystem='APFS'
 
-    if [ "$( /usr/bin/sw_vers -productVersion | awk -F. '{ print ($1 * 10 ** 2 +  $2 )}' )" -lt 1015 ]; then
+    if [ "$( /usr/bin/sw_vers -productVersion | /usr/bin/awk -F. '{ print ($1 * 10 ** 2 +  $2 )}' )" -lt 1015 ]; then
         filesystem='JHFS+'
     fi
 
     /usr/bin/hdiutil create -size $(( sizeOfInstaller + extra_size ))m -volname "$volumename" "$temp_dmg" -fs "$filesystem" > /dev/null
-    devfile="$( /usr/bin/hdiutil attach -readwrite -nobrowse "$temp_dmg" | awk '$NF == "GUID_partition_scheme" {print $1}' )"
+    devfile="$( /usr/bin/hdiutil attach -readwrite -nobrowse "$temp_dmg" | /usr/bin/awk '$NF == "GUID_partition_scheme" {print $1}' )"
 
     /bin/mkdir "/Volumes/${volumename}/Applications"
     if /bin/cp -a "${OSInstaller%/}" "/Volumes/${volumename}/Applications" ; then


### PR DESCRIPTION
Fixed #160 

- Run this on Mojave, require more space. https://github.com/kc9wwh/macOSUpgrade/pull/161/commits/0380d8a0f34a0188ffe5e90f8edfee044e6b2781
- Converting dmg file on Mojave, put error out. Use JHFS+ instead of APFS. https://github.com/kc9wwh/macOSUpgrade/pull/161/commits/0380d8a0f34a0188ffe5e90f8edfee044e6b2781
- More space on Catalina.  https://github.com/kc9wwh/macOSUpgrade/pull/161/commits/1487bb610cd0aba28b58548b4cff2e6b89321f98

=====
```
ladmin@vmac02:macOSUpgrade/[181]$ sw_vers; df -H
ProductName:    Mac OS X
ProductVersion: 10.14.6
BuildVersion:   18G6042
Filesystem                     Size   Used  Avail Capacity iused               ifree %iused  Mounted on
/dev/disk1s1                   107G    52G    54G    49%  536561 9223372036854239246    0%   /
devfs                          188k   188k     0B   100%     640                   0  100%   /dev
/dev/disk1s4                   107G    20k    54G     1%       0 9223372036854775807    0%   /private/var/vm
map -hosts                       0B     0B     0B   100%       0                   0  100%   /net
map auto_home                    0B     0B     0B   100%       0                   0  100%   /home
.host:/VMware Shared Folders   2.0T   2.0T    40G    99%       0                   0  100%   /Volumes/VMware Shared Folders
ladmin@vmac02:macOSUpgrade/[182]$ ./helper-tools/prepare-jamf-policy.sh /Applications/Inst
Install macOS Big Sur.app/  Install macOS Catalina.app/
ladmin@vmac02:macOSUpgrade/[182]$ ./helper-tools/prepare-jamf-policy.sh /Applications/Install\ macOS\ Big\ Sur.app/
Wait seconds, getting checksum...

=====================================================
Parameters for JamfPro policy:
Parameter 4: /Applications/Install macOS Big Sur.app
Parameter 5: 11.0.1
Parameter 6: (Your download trigger policy)
Parameter 7: b5df443ec0ead5e8daac39fba6bc401e
=====================================================

Would you need a DMG file of Install macOS Big Sur.app? [y/n]: y
Ok, building DMG file of Install macOS Big Sur.app. Wait few minutes.
Done. /Users/ladmin/Downloads/Install macOS Big Sur.app.11.0.1.dmg
ladmin@vmac02:macOSUpgrade/[183]$
```

```
ladmin@vmac06:Documents/macOSUpgrade[195]% sw_vers; df -H
ProductName:    Mac OS X
ProductVersion: 10.15.7
BuildVersion:   19H15
Filesystem                     Size   Used  Avail Capacity iused      ifree %iused  Mounted on
/dev/disk1s5                   107G    11G    76G    13%  488300 1046039300    0%   /
devfs                          191k   191k     0B   100%     650          0  100%   /dev
/dev/disk1s1                   107G    19G    76G    20%  166410 1046361190    0%   /System/Volumes/Data
/dev/disk1s4                   107G   1.1M    76G     1%       1 1046527599    0%   /private/var/vm
.host:/VMware Shared Folders   2.0T   2.0T    46G    98%       0          0  100%   /Volumes/VMware Shared Folders
map auto_home                    0B     0B     0B   100%       0          0  100%   /System/Volumes/Data/home
ladmin@vmac06:Documents/macOSUpgrade[196]% ./helper-tools/prepare-jamf-policy.sh /Applications/Install\ macOS\ Big\ Sur.app
Wait seconds, getting checksum...

=====================================================
Parameters for JamfPro policy:
Parameter 4: /Applications/Install macOS Big Sur.app
Parameter 5: 11.0.1
Parameter 6: (Your download trigger policy)
Parameter 7: b5df443ec0ead5e8daac39fba6bc401e
=====================================================

Would you need a DMG file of Install macOS Big Sur.app? [y/n]: y
Ok, building DMG file of Install macOS Big Sur.app. Wait few minutes.
Done. /Users/ladmin/Downloads/Install macOS Big Sur.app.11.0.1.dmg
ladmin@vmac06:Documents/macOSUpgrade[197]%
```
