### PR TITLE
Adding job control to address an issue where macOSUpgrade process quitting was also quitting child processes

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -562,6 +562,9 @@ fi
 # APPLICATION
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+#Enabling job control to ensure all following processes run in a separate process group
+set -m
+
 ## Launch jamfHelper
 jamfHelperPID=""
 if [ "$userDialog" -eq 0 ]; then
@@ -629,5 +632,8 @@ eval "$startosinstallCommand"
 if [ "$ShowLogFile" = "yes" ]; then
     launchctl asuser "$( id -u "$3" )" /usr/bin/open "${osinstallLogfile}"
 fi
+
+#Disabling job control
+set +m
 
 exit 0


### PR DESCRIPTION
Added set -m to enable job control for the Application section of the script. The solution for this fix to issue #44 was proposed by fponcelin in https://github.com/kc9wwh/macOSUpgrade/issues/44#issuecomment-578631891:~:text=fponcelin%20commented%20on%2027%20Jan%202020

Reference for set builtin command
https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html