### PR TITLE
macOS Monterey Compatible Version

### DIFF
--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -644,9 +644,6 @@ fi
 # APPLICATION
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-#Enabling job control to ensure all following processes run in a separate process group
-set -m
-
 ## Launch jamfHelper
 jamfHelperPID=""
 if [ "$userDialog" -eq 0 ]; then
@@ -714,8 +711,5 @@ eval "$startosinstallCommand"
 if [ "$ShowLogFile" = "yes" ]; then
     launchctl asuser "$( id -u "$3" )" /usr/bin/open "${osinstallLogfile}"
 fi
-
-#Disabling job control
-set +m
 
 exit 0

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -339,7 +339,17 @@ validate_free_space() {
             || /usr/libexec/PlistBuddy -c "Print :AvailableSpace" /dev/stdin <<<"$diskInfoPlist" 2>/dev/null
     )
 
-    if [ "$installerVersion" -ge 1100 ]; then
+    if [ "$installerVersion" -ge 1200 ]; then
+        estInstallerSizeBytes=$(( 13 * 1000 ** 3 ))
+        # macOS Monterey or later (version 12.0~)
+        # https://support.apple.com/en-us/HT212735
+        if [ "$localOSVersion" -ge 1012 ]; then
+            # Mac OS X 10.12 Sierra or later
+            requiredDiskSpaceSizeGB=26
+        else
+            requiredDiskSpaceSizeGB=45
+        fi
+    elif [ "$installerVersion" -ge 1100 ]; then
         estInstallerSizeBytes=$(( 13 * 1000 ** 3 ))
         # macOS Big Sur or later (version 11.0~)
         # https://support.apple.com/HT211238
@@ -366,10 +376,10 @@ validate_free_space() {
         requiredDiskSpaceSizeGB=13
     fi
 
-    # The free space calculation sbutract the installer size when it is not installed yet.
+    # The free space calculation subtracts the installer size when it is not installed yet.
     if [ ! -e "$installerPath" ]; then
         freeSpace=$((freeSpace - estInstallerSizeBytes))
-        noInstallerMsg=" with the installer installed. Additinal about $(( estInstallerSizeBytes / 1000 ** 3 )) GB required."
+        noInstallerMsg=" with the installer installed. Additional about $(( estInstallerSizeBytes / 1000 ** 3 )) GB required."
     fi
 
     if [ "$freeSpace" -ge "$((requiredDiskSpaceSizeGB * 1000 ** 3))" ]; then

--- a/macOSUpgrade.sh
+++ b/macOSUpgrade.sh
@@ -644,6 +644,9 @@ fi
 # APPLICATION
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+#Enabling job control to ensure all following processes run in a separate process group
+set -m
+
 ## Launch jamfHelper
 jamfHelperPID=""
 if [ "$userDialog" -eq 0 ]; then
@@ -711,5 +714,8 @@ eval "$startosinstallCommand"
 if [ "$ShowLogFile" = "yes" ]; then
     launchctl asuser "$( id -u "$3" )" /usr/bin/open "${osinstallLogfile}"
 fi
+
+#Disabling job control
+set +m
 
 exit 0


### PR DESCRIPTION
## What: Updated for macOS Monterey Installer compatibility.
## Why?: macOS Monterey has a lower storage requirement than macOS Big Sur, and adding additional logic to the function enables 10 GB of additional freedom with upgrades.
## How?: Expanded the validate_free_space function with additional logic to separate Monterey and Big Sur Installers
## Testing?: Tested to confirm the expanded function is working correctly at differentiating 12.0.1 and 11.6.1 installers and checks for the appropriate amount of free space.
## Anything Else?: Corrected a couple of typos for better readability.